### PR TITLE
Making Total learners section sticky Fix: issue #82

### DIFF
--- a/client/src/pages/Leaderboard/index.css
+++ b/client/src/pages/Leaderboard/index.css
@@ -4,11 +4,20 @@
 }
 
 .leaderboard-container .stats {
-  width: 30%;
+  width: 25%;
+  position: fixed;
+  right: 0;
+  top: 85px;
+  height: 85%;
   padding: 6rem 2rem 0 2rem;
   font-family: var(--ff-mono);
   border-left: 1px solid rgb(163, 168, 195, 0.2);
   text-align: center;
+}
+
+.leaderboard-container .stats-icon {
+  block-size: auto;
+  max-inline-size: 88%;
 }
 
 .leaderboard-container .stats-title {

--- a/client/src/pages/Leaderboard/index.jsx
+++ b/client/src/pages/Leaderboard/index.jsx
@@ -55,7 +55,7 @@ const Leaderboard = () => {
         </div>
         <div className="stats">
           <div>
-            <img src={Users} alt="" />
+            <img className="stats-icon" src={Users} alt="" />
             <p className="stats-title">Total Learners</p>
             <p className="stats-count">{totalLearners}</p>
           </div>


### PR DESCRIPTION

## Fixes Issue

This PR fixes the following issues:

closes #82 Style: make the total learners' section on the leaderboard page sticky


